### PR TITLE
add support for bunyan style log method: log.info({foo: 'bar'}, 'hi');

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,6 @@ ENV/
 
 # Rope project settings
 .ropeproject
+
+# PyCharm project settings
+.idea/

--- a/bunyan/formatter.py
+++ b/bunyan/formatter.py
@@ -16,6 +16,7 @@ from inspect import istraceback
 try:
   from collections import OrderedDict
 except ImportError:
+  OrderedDict = dict
   pass
 
 def object_startswith(key, value):
@@ -149,10 +150,7 @@ class BunyanFormatter(logging.Formatter):
     if record.exc_info and not message_dict.get('exc_info'):
       message_dict['exc_info'] = self.formatException(record.exc_info)
 
-    try:
-      log_record = OrderedDict()
-    except NameError:
-      log_record = {}
+    log_record = OrderedDict()
 
     self.add_fields(log_record, record, message_dict)
     log_record = self.process_log_record(log_record)

--- a/bunyan/formatter.py
+++ b/bunyan/formatter.py
@@ -4,7 +4,7 @@ Bunyan Formatter.
 Provides logging compatibility with Bunyan standard and enceforth CLI.
 """
 import datetime
-import json
+import simplejson as json
 import logging
 import re
 import socket
@@ -128,7 +128,7 @@ class BunyanFormatter(logging.Formatter):
     """
     Returns a json string of the log record.
     """
-    return json.dumps(log_record, default = self.json_default)
+    return json.dumps(log_record, default = self.json_default, ignore_nan=True)
 
   def format(self, record):
     """

--- a/bunyan/formatter.py
+++ b/bunyan/formatter.py
@@ -138,7 +138,12 @@ class BunyanFormatter(logging.Formatter):
 
     if isinstance(record.msg, dict):
       message_dict = record.msg
-      record.message = None
+      if len(record.args) == 1 and isinstance(record.args[0], str):
+        # bunyan style log method: fields object + msg string
+        record.msg = record.args[0]
+        record.message = record.args[0] % message_dict
+      else:
+        record.message = None
     else:
       record.message = record.getMessage()
     # only format time if needed

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+simplejson


### PR DESCRIPTION
I'd like to continue using one of node-bunyan's log method style, but not working correctly in latest python-bunyan:

For
`logger.info({'foo': 'bar'}, 'hi');
`
# expected:

`{"name": "__main__", "foo": "bar", "msg": "hi", "time": "2016-08-02T03:37:28Z", "hostname": "cymp.local", "level": 30, "pid": 8643, "v": 0}
`
# but msg is empty:

`{"name": "__main__", "foo": "bar", "msg": "", "time": "2016-08-02T03:41:38Z", "hostname": "cymp.local", "level": 30, "pid": 10003, "v": 0}
`

And I updated the code for it to work as expected.

So far `nosetests tests` passed for 3.5.2/2.7

```
cymp:python-bunyan cyue$ python -V
Python 3.5.2 :: Anaconda 4.1.1 (x86_64)
cymp:python-bunyan cyue$ nosetests tests 
.......
----------------------------------------------------------------------
Ran 7 tests in 0.004s

OK

```

```
cymp:python-bunyan cyue$ python -V
Python 2.7.10
cymp:python-bunyan cyue$ nosetests tests 
.......
----------------------------------------------------------------------
Ran 7 tests in 0.004s

OK

```
